### PR TITLE
Add header images and caching improvements

### DIFF
--- a/giveaway.py
+++ b/giveaway.py
@@ -63,7 +63,7 @@ class GiveawayModal(Modal, title="🎉 Nowy Giveaway"):
             color=EMBED_COLOR,
             timestamp=datetime.now(timezone.utc) + timedelta(seconds=czas_s)
         )
-        embed.set_thumbnail(url="attachment://giveawey.png")
+        embed.set_image(url="attachment://giveawey.png")
         embed.set_footer(text="Kliknij przycisk poniżej, aby wziąć udział!")
 
         view = GiveawayView(booster_id, liczba, zwyciezcy, czas_s)


### PR DESCRIPTION
## Summary
- display large header graphics above embeds for shop, cart, collection, set selection and giveaway
- add button to quickly add another booster in cart view
- compute booster prices per set and show them in shop
- cache API results of cards by set/rarity
- tweak card reveal to reliably show card back between cards

## Testing
- `python -m py_compile bot.py giveaway.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6846adda06dc832fa21c552ae6d8932b