### PR TITLE
Add streak rewards and emoji fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
    ```ini
    BOT_TOKEN=twoj_token_bota
    POKETCG_API_KEY=twoj_klucz_api
+   # Opcjonalnie ID emoji bc_coin na Twoim serwerze
+   BC_COIN_ID=123456789012345678
    ```
 3. Uruchom bota:
    ```bash
@@ -39,7 +41,7 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
 
 - `/start` – załóż konto i odbierz startową pulę monet.
 - `/saldo` – sprawdź aktualną ilość posiadanych monet.
-- `/daily` – codzienna nagroda pieniędzy (24 h cooldown).
+- `/daily` – codzienna nagroda pieniędzy (24 h cooldown). Co 7 dni serii otrzymasz bonus monet.
 - `/sklep` – otwiera widok sklepu z boosterami i przedmiotami.
 - `/kup_booster <kod>` – szybki zakup jednego boostera podając kod zestawu.
 - `/kolekcja` – wyświetla Twoją kolekcję kart i boosterów.


### PR DESCRIPTION
## Summary
- fix displaying `bc_coin` emoji via env variable
- weight mystery booster selection by price
- grant bonus coins every 7‑day daily streak
- keep streak after using Streak Freeze
- highlight item names and top booster in shop
- add extra emojis for flavor
- document `BC_COIN_ID` variable and streak bonus in README

## Testing
- `python3 -m py_compile bot.py poke_utils.py giveaway.py`

------
https://chatgpt.com/codex/tasks/task_e_6846defeb988832f801fb7862293c04a