### PR TITLE
Improve weekly ranking and drop channel

### DIFF
--- a/poke_utils.py
+++ b/poke_utils.py
@@ -36,7 +36,7 @@ def ensure_user_fields(user):
     user.setdefault("money", 0)
     user.setdefault("last_daily", 0)
     user.setdefault("daily_streak", 0)
-    user.setdefault("weekly_best", {"week": 0, "year": 0, "price": 0})
+    user.setdefault("weekly_best", {"week": 0, "year": 0, "price": 0, "name": ""})
     user.setdefault("achievements", [])
     return user
 


### PR DESCRIPTION
## Summary
- track best card name and value for weekly ranking
- show drop notifications only for rarest cards
- post automatic weekly ranking and reward coins
- embed shop cart image correctly

## Testing
- `python -m py_compile bot.py poke_utils.py giveaway.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e4d624bc832f835456894ba09bd0