### PR TITLE
Dodanie komendy help i nowych osiągnięć

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
 - `/saldo` – sprawdź aktualną ilość posiadanych monet.
 - `/daily` – codzienna nagroda pieniędzy (24 h cooldown). Co 7 dni serii otrzymasz bonus 200 BC.
 - `/sklep` – otwiera widok sklepu z boosterami i przedmiotami.
-- `/kup_booster <kod>` – szybki zakup jednego boostera podając kod zestawu.
 - `/kolekcja` – wyświetla Twoją kolekcję kart i boosterów.
 - `/osiagniecia` – lista zdobytych osiągnięć.
 - `/ranking` – najlepsze dropy tygodnia.
+- `/help` – lista wszystkich komend bota.
 - `/otworz` – otwórz posiadane boostery i odsłaniaj karty jedna po drugiej.
 - `/giveaway` – stwórz losowanie boosterów (administrator).
 

--- a/poke_utils.py
+++ b/poke_utils.py
@@ -33,6 +33,7 @@ def ensure_user_fields(user):
     user.setdefault("rare_boost", 0)
     user.setdefault("double_daily_until", 0)
     user.setdefault("streak_freeze", 0)
+    user.setdefault("boosters_opened", 0)
     user.setdefault("money", 0)
     user.setdefault("last_daily", 0)
     user.setdefault("daily_streak", 0)


### PR DESCRIPTION
## Podsumowanie
- polskie powitanie podczas zakładania konta
- nowa komenda `/help` z opisem wszystkich poleceń
- osiągnięcia za zakładanie konta, 10-dniowy streak i otwieranie boosterów
- informacja o dniu w tygodniowej serii w `/daily`
- usunięto komendę `/kup_booster` oraz odnośniki w README

## Testy
- `python3 -m py_compile bot.py poke_utils.py giveaway.py`


------
https://chatgpt.com/codex/tasks/task_e_6847c7130dec832fb684498c1cf28161