### PR TITLE
Add extended achievements system

### DIFF
--- a/poke_utils.py
+++ b/poke_utils.py
@@ -1,4 +1,5 @@
 import json
+import time
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -39,6 +40,7 @@ def ensure_user_fields(user):
     user.setdefault("daily_streak", 0)
     user.setdefault("weekly_best", {"week": 0, "year": 0, "price": 0, "name": ""})
     user.setdefault("achievements", [])
+    user.setdefault("created_at", int(time.time()))
     return user
 
 


### PR DESCRIPTION
## Summary
- expand achievement list with many new goals
- track boosters, cards, rares and sets when opening booster
- store card rarity
- show progress bars in `/osiagniecia`
- store account creation time for time based achievements

## Testing
- `python -m py_compile bot.py poke_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6847cb659f58832fb55ff94d9ee9078f