### PR TITLE
Fix interaction timeout for booster summary

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1233,6 +1233,7 @@ class CardRevealView(View):
             self.parent = parent
 
         async def callback(self, interaction: discord.Interaction):
+            await interaction.response.defer()
             users = load_users()
             uid = str(self.parent.user_id)
             if uid in users:


### PR DESCRIPTION
## Summary
- allow extra processing time in summary button callback

## Testing
- `pytest -q`
- `python -m py_compile bot.py poke_utils.py giveaway.py`


------
https://chatgpt.com/codex/tasks/task_e_6847e4446b10832fa5d30807af38137d