### PR TITLE
Add CLI pagination script and fix card reveal

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1512,6 +1512,9 @@ class CardRevealView(View):
         return str(interaction.user.id) == self.user_id
 
     async def show_card(self, interaction, first=False):
+        if self.index >= len(self.cards):
+            await self.finalize(interaction)
+            return
         card = self.cards[self.index]
         rarity = card.get("rarity", "Unknown")
         emoji = RARITY_EMOJIS.get(rarity, "❔")

--- a/collect.py
+++ b/collect.py
@@ -1,0 +1,47 @@
+import argparse
+import math
+from poke_utils import load_users, ensure_user_fields
+
+PAGE_SIZE = 10
+
+def paginate(items, page_size=PAGE_SIZE):
+    total_pages = math.ceil(len(items) / page_size)
+    page = 0
+    while True:
+        start = page * page_size
+        end = start + page_size
+        print(f"\nPage {page + 1}/{total_pages}")
+        for item in items[start:end]:
+            print(item)
+        if total_pages == 0:
+            break
+        cmd = input("(n)ext, (p)rev, (q)uit: ").lower()
+        if cmd == 'n' and page < total_pages - 1:
+            page += 1
+        elif cmd == 'p' and page > 0:
+            page -= 1
+        elif cmd == 'q':
+            break
+        else:
+            print("Invalid input")
+
+def main():
+    parser = argparse.ArgumentParser(description="Show user card collection")
+    parser.add_argument("user_id", help="Discord user ID")
+    args = parser.parse_args()
+
+    users = load_users()
+    uid = str(args.user_id)
+    if uid not in users:
+        print("User not found")
+        return
+    user = ensure_user_fields(users[uid])
+    cards = user.get("cards", [])
+    entries = [f"{c['id']} - {c.get('name', '')} ({c.get('price_usd',0)} USD)" for c in cards]
+    if not entries:
+        print("No cards")
+        return
+    paginate(entries)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small `collect.py` script to browse user cards with pagination
- guard against index errors in `CardRevealView.show_card`

## Testing
- `python3 -m py_compile bot.py giveaway.py poke_utils.py collect.py`

------
https://chatgpt.com/codex/tasks/task_e_68488db1f828832f9ece6d4774250d1b