### PR TITLE
Fix ranking command tuple unpack

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1876,7 +1876,7 @@ async def ranking_cmd(interaction: discord.Interaction):
     await interaction.response.send_message(embed=embed, ephemeral=True)
     changed = False
     notify = []
-    for uid,_ in top3:
+    for uid, _, _ in top3:
         ensure_user_fields(users[uid])
         if grant_achievement(users[uid], "top3_week"):
             notify.append(uid)


### PR DESCRIPTION
## Summary
- fix tuple unpacking in ranking command

## Testing
- `python3 -m py_compile bot.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement discord.py>=2.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_6848996390dc832f9c49ef0c3606b5cc