### PR TITLE
Add community vote feature and improve shop UI

### DIFF
--- a/poke_utils.py
+++ b/poke_utils.py
@@ -53,6 +53,7 @@ def ensure_user_fields(user):
     user.setdefault("last_daily", 0)
     user.setdefault("daily_streak", 0)
     user.setdefault("weekly_best", {"week": 0, "year": 0, "price": 0, "name": ""})
+    user.setdefault("weekly_community", {"week": 0, "year": 0, "score": 0})
     user.setdefault("achievements", [])
     user.setdefault("badges", [])
     user.setdefault("created_at", int(time.time()))


### PR DESCRIPTION
## Summary
- move `shop.png` image to embed thumbnail
- add `DropRatingView` for community reactions
- show concise public booster summary with rating button
- track weekly community votes and include in ranking
- support new `community_week` achievement

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849235b18bc832f837e1ffe61f22901