### PR TITLE
Improve booster purchase summary

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -341,7 +341,7 @@ def build_achievement_pages(user, all_sets):
     pages = []
     for title, entries in ACHIEVEMENT_GROUPS:
         embed = create_embed(title=title, color=discord.Color.green())
-        embed.set_thumbnail(url="attachment://achivment.png")
+        embed.set_image(url="attachment://achivment.png")
         for code, target in entries:
             value = 0
             tgt = target
@@ -526,7 +526,7 @@ def build_cart_embed(user_id, message):
     cart = carts.get(user_id, {"boosters": {}, "items": {}})
     total = compute_cart_total(cart)
     embed = create_embed(title="Koszyk", description=message, color=EMBED_COLOR)
-    embed.set_thumbnail(url="attachment://koszyk.png")
+    embed.set_image(url="attachment://koszyk.png")
     embed.add_field(name="Wartość koszyka", value=format_bc(total), inline=False)
     embed.add_field(name="Twoje saldo", value=format_bc(money), inline=False)
     if money < total:
@@ -790,7 +790,18 @@ class ShopView(View):
         carts.pop(uid, None)
         await self.update()
         emj = random.choice(FUN_EMOJIS)
-        msg = f"{emj} Zakupiono za {format_bc(total)}"
+        sets = get_all_sets()
+        id_to_code = {s["id"]: s.get("ptcgoCode", s["id"]) for s in sets}
+        parts = []
+        for sid, q in cart.get("boosters", {}).items():
+            code = id_to_code.get(sid, sid)
+            part = f"{code} x{q}" if q > 1 else code
+            parts.append(part)
+        booster_info = ", ".join(parts)
+        msg = f"{emj} Zakupiono"
+        if booster_info:
+            msg += f" {booster_info}"
+        msg += f" za {format_bc(total)}"
         if mystery_results:
             boosters = ", ".join(mystery_results)
             msg += f"\nWylosowano: {boosters}"
@@ -868,17 +879,17 @@ class ShopView(View):
                                     await i4.response.send_modal(modal)
 
                             embed = create_embed(title="Wybierz set", color=EMBED_COLOR)
-                            embed.set_thumbnail(url="attachment://wybierz_set.png")
+                            embed.set_image(url="attachment://wybierz_set.png")
                             file = discord.File(GRAPHIC_DIR / "wybierz_set.png", filename="wybierz_set.png")
                             await i3.response.edit_message(embed=embed, view=SetView(self.shop_view), attachments=[file])
 
                     embed = create_embed(title="Wybierz erę", color=EMBED_COLOR)
-                    embed.set_thumbnail(url="attachment://wybierz_set.png")
+                    embed.set_image(url="attachment://wybierz_set.png")
                     file = discord.File(GRAPHIC_DIR / "wybierz_set.png", filename="wybierz_set.png")
                     await i2.response.edit_message(embed=embed, view=EraView(self.parent.parent), attachments=[file])
 
             embed = create_embed(title="Wybierz język", color=EMBED_COLOR)
-            embed.set_thumbnail(url="attachment://wybierz_set.png")
+            embed.set_image(url="attachment://wybierz_set.png")
             file = discord.File(GRAPHIC_DIR / "wybierz_set.png", filename="wybierz_set.png")
             await interaction.response.send_message(embed=embed, view=LanguageView(self), ephemeral=True, file=file)
 
@@ -912,7 +923,7 @@ class ShopView(View):
                     await i2.response.send_modal(modal)
 
             embed = create_embed(title="Wybierz item", color=EMBED_COLOR)
-            embed.set_thumbnail(url="attachment://koszyk.png")
+            embed.set_image(url="attachment://koszyk.png")
             file = discord.File(GRAPHIC_DIR / "koszyk.png", filename="koszyk.png")
             await interaction.response.send_message(embed=embed, view=ItemSelectView(self), ephemeral=True, files=[file])
 
@@ -1068,7 +1079,7 @@ class MyClient(discord.Client):
                     else:
                         embed.description = f"Typ: {ev.get('type')}"
                     file = discord.File(GRAPHIC_DIR / "logo.png", filename="logo.png")
-                    embed.set_thumbnail(url="attachment://logo.png")
+                    embed.set_image(url="attachment://logo.png")
                     channel = self.get_channel(DROP_CHANNEL_ID)
                     if channel:
                         await channel.send(embed=embed, file=file)
@@ -1227,7 +1238,7 @@ class CollectionMainView(View):
                 description="\n".join(lines),
                 color=EMBED_COLOR
             )
-            embed.set_thumbnail(url="attachment://sety.png")
+            embed.set_image(url="attachment://sety.png")
             file = discord.File(GRAPHIC_DIR / "sety.png", filename="sety.png")
             await interaction.response.send_message(embed=embed, ephemeral=True, file=file)
 
@@ -1295,7 +1306,7 @@ class CollectionMainView(View):
                 description="Wybierz set z listy poniżej",
                 color=EMBED_COLOR,
             )
-            embed.set_thumbnail(url="attachment://sety.png")
+            embed.set_image(url="attachment://sety.png")
             file = discord.File(GRAPHIC_DIR / "sety.png", filename="sety.png")
             await interaction.response.send_message(embed=embed, view=view, ephemeral=True, file=file)
     class BoosterOpenButton(Button):
@@ -1363,7 +1374,7 @@ async def build_set_embed(user, sets, set_id):
         ),
         color=EMBED_COLOR
     )
-    embed.set_thumbnail(url="attachment://sety.png")
+    embed.set_image(url="attachment://sety.png")
     if top5:
         lines = []
         for idx, (cid, name, price, url) in enumerate(top5):
@@ -1736,7 +1747,7 @@ async def start_cmd(interaction: discord.Interaction):
         description=welcome,
         color=discord.Color.green()
     )
-    embed.set_thumbnail(url="attachment://CardCollector.png")
+    embed.set_image(url="attachment://CardCollector.png")
     file = discord.File(GRAPHIC_DIR / "CardCollector.png", filename="CardCollector.png")
     await interaction.response.send_message(embed=embed, ephemeral=True, file=file)
     await send_achievement_message(interaction, "account_created")


### PR DESCRIPTION
## Summary
- enlarge header graphics on several embeds
- show short booster codes and quantity when checking out

## Testing
- `python3 -m py_compile bot.py`
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68492dc338ec832fa404e270eb3c46bf