### PR TITLE
Fix embed headers and rename profile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
 - `/saldo` – sprawdź aktualną ilość posiadanych monet.
 - `/daily` – codzienna nagroda pieniędzy (24 h cooldown). Co 7 dni serii otrzymasz bonus 200 BC.
 - `/sklep` – otwiera widok sklepu z boosterami i przedmiotami.
-- `/kolekcja` – wyświetla Twoją kolekcję kart i boosterów.
+- `/profil` – wyświetla Twój profil z kartami i boosterami.
 - `/osiagniecia` – lista zdobytych osiągnięć.
 - `/ranking` – najlepsze dropy tygodnia.
 - `/help` – lista wszystkich komend bota.

--- a/giveaway.py
+++ b/giveaway.py
@@ -58,7 +58,6 @@ class GiveawayModal(Modal, title="🎉 Nowy Giveaway"):
         embed.timestamp = datetime.now(timezone.utc) + timedelta(seconds=czas_s)
         if logo_url:
             embed.set_thumbnail(url=logo_url)
-        embed.set_image(url="attachment://giveawey.png")
         embed.set_footer(text="Kliknij przycisk poniżej, aby wziąć udział!")
 
         view = GiveawayView(booster_id, liczba, zwyciezcy, czas_s)


### PR DESCRIPTION
## Summary
- remove extra image from giveaway embeds
- update cart, set selection, and achievements to display header images above embeds
- simplify booster selection by omitting language choice
- rename `kolekcja` command and related text to `profil`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684930b24db4832f9223620a28ef0f1a