### PR TITLE
Fix AddBoosterButton not passing ShopView

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -871,7 +871,7 @@ class ShopView(View):
 
             embed = create_embed(title="Wybierz erę", color=EMBED_COLOR)
             file = discord.File(GRAPHIC_DIR / "wybierz_set.png", filename="wybierz_set.png")
-            await interaction.response.send_message(embed=embed, view=EraView(self), ephemeral=True, file=file)
+            await interaction.response.send_message(embed=embed, view=EraView(self.parent), ephemeral=True, file=file)
 
     class AddItemButton(Button):
         def __init__(self, parent):


### PR DESCRIPTION
## Summary
- ensure `AddBoosterButton` passes the `ShopView` instance to `EraView`

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68493629c134832fb0d29103808a8db4