### PR TITLE
Fix drop summary view

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1627,7 +1627,7 @@ class CardRevealView(View):
             public_msg = (
                 f"{interaction.user.display_name} otworzył {booster_name} o wartości {format_bc(total_bc)}"
             )
-            await interaction.followup.send(content=public_msg, embed=public_embed, view=DropRatingView(self.user_id), ephemeral=False)
+            await interaction.followup.send(content=public_msg, embed=public_embed, view=QuickBonusView.DropRatingView(self.user_id), ephemeral=False)
 
     async def interaction_check(self, interaction):
         return str(interaction.user.id) == self.user_id


### PR DESCRIPTION
## Summary
- reference DropRatingView correctly when sending public summary

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6849771d42f4832f988e1be8ceb19f4e