### PR TITLE
Fix item select emoji

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -903,10 +903,16 @@ class ShopView(View):
             self.parent = parent
 
         async def callback(self, interaction: discord.Interaction):
-            options = [
-                discord.SelectOption(label=f"{info['name']} {info.get('emoji', '')}", value=iid)
-                for iid, info in ITEMS.items()
-            ]
+            options = []
+            for iid, info in ITEMS.items():
+                emoji_str = info.get("emoji")
+                if emoji_str and emoji_str.startswith("<"):
+                    emoji = discord.PartialEmoji.from_str(emoji_str)
+                else:
+                    emoji = emoji_str
+                options.append(
+                    discord.SelectOption(label=info["name"], value=iid, emoji=emoji)
+                )
 
             class ItemSelectView(View):
                 def __init__(self, parent):


### PR DESCRIPTION
## Summary
- make the shop item dropdown use the emoji field

## Testing
- `python -m py_compile bot.py poke_utils.py giveaway.py collect.py`


------
https://chatgpt.com/codex/tasks/task_e_68497876f3e8832f848b3f46b01fac34