### PR TITLE
Fix giveaway reward handing to create user if missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
   i finalizuj zakupy w jednym miejscu.
 - **Osiągnięcia i ranking tygodniowy** – zdobywaj odznaki za master sety,
   30‑dniowy streak i najlepszy drop tygodnia.
-- **Giveaway** – administratorzy mogą tworzyć losowania boosterów.
+ - **Giveaway** – administratorzy mogą tworzyć losowania boosterów.
+   Zwycięzcy otrzymują nagrody automatycznie i dostają powiadomienie w DM.
 - **Eventy** – czasowe bonusy jak podwójne monety lub zwiększona szansa na drop.
 
 ## Instalacja

--- a/giveaway.py
+++ b/giveaway.py
@@ -10,6 +10,7 @@ from poke_utils import (
     EMBED_COLOR,
     create_embed,
     load_channels,
+    ensure_user_fields,
 )
 from pathlib import Path
 
@@ -104,8 +105,16 @@ class GiveawayView(View):
         users = load_users()
         for uid in chosen:
             uid_str = str(uid)
-            if uid_str in users:
-                users[uid_str]["boosters"].extend([self.booster_id] * self.ilosc)
+            member = None
+            if self.message and self.message.guild:
+                try:
+                    member = await self.message.guild.fetch_member(uid)
+                except Exception:
+                    member = None
+            user = users.get(uid_str, {"username": member.name if member else str(uid)})
+            ensure_user_fields(user)
+            user["boosters"].extend([self.booster_id] * self.ilosc)
+            users[uid_str] = user
         save_users(users)
         mentions = ", ".join(f"<@{uid}>" for uid in chosen)
         await self.message.channel.send(f"🏆 Gratulacje! Giveaway wygrywają: {mentions}")


### PR DESCRIPTION
## Summary
- ensure giveaway winners receive boosters even if they have no account yet
- note in README that winners get DM notification

## Testing
- `python -m py_compile giveaway.py`
- `python -m py_compile poke_utils.py`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684a68ef9a44832f82b3ef6824f60f14