### PR TITLE
Add admin reward command and fix duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
 - `/help` – lista wszystkich komend bota.
 - `/otworz` – otwórz posiadane boostery i odsłaniaj karty jedna po drugiej.
 - `/giveaway` – stwórz losowanie boosterów (administrator).
+- `/nagroda` – przyznaj booster lub monety wybranemu graczowi (administrator).
 
 Poniżej przykład grafiki jednego z setów dostępnych w sklepie:
 


### PR DESCRIPTION
## Summary
- prevent progress overflow in achievement display
- avoid duplicate best card messages when opening boosters
- add `/nagroda` admin command to grant boosters or coins
- document new command in README

## Testing
- `python3 -m py_compile bot.py giveaway.py poke_utils.py collect.py`

------
https://chatgpt.com/codex/tasks/task_e_684a861e9450832f8019ba30632dd679