### PR TITLE
Fix booster summary and giveaway timer

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1641,7 +1641,13 @@ class CardRevealView(View):
             public_msg = (
                 f"{interaction.user.display_name} otworzył {booster_name} o wartości {format_bc(total_bc)}"
             )
-            await interaction.followup.send(content=public_msg, embed=public_embed, view=QuickBonusView.DropRatingView(self.user_id), ephemeral=False)
+            target_channel = None
+            if interaction.guild:
+                target_channel = interaction.guild.get_channel(SHOP_CHANNEL_ID)
+            if target_channel:
+                await target_channel.send(content=public_msg, embed=public_embed, view=QuickBonusView.DropRatingView(self.user_id))
+            else:
+                await interaction.followup.send(content=public_msg, embed=public_embed, view=QuickBonusView.DropRatingView(self.user_id), ephemeral=False)
         self.stop()
 
     async def interaction_check(self, interaction):
@@ -2415,13 +2421,6 @@ async def fetch_cards_from_set(set_id: str, user_id: str = None):
     rares = [c for c in result if c.get("rarity") not in ["Common", "Uncommon"]]
     random.shuffle(commons)
     cards_result = commons + rares
-    unique = []
-    seen = set()
-    for card in cards_result:
-        cid = card.get("id")
-        if cid not in seen:
-            unique.append(card)
-            seen.add(cid)
-    return unique[:10]
+    return cards_result[:10]
 
 client.run(os.environ["BOT_TOKEN"])

--- a/giveaway.py
+++ b/giveaway.py
@@ -167,13 +167,24 @@ class GiveawayView(View):
             return
 
         remaining_seconds = int((self.message.embeds[0].timestamp - datetime.now(timezone.utc)).total_seconds())
+        days, rem = divmod(remaining_seconds, 86400)
+        hours, rem = divmod(rem, 3600)
+        minutes, seconds = divmod(rem, 60)
+        time_parts = []
+        if days:
+            time_parts.append(f"{days}d")
+        if hours or days:
+            time_parts.append(f"{hours}h")
+        time_parts.append(f"{minutes}m {seconds}s")
+        remaining_str = " ".join(time_parts)
+
         names = [f"<@{uid}>" for uid in self.entries]
 
         embed = self.message.embeds[0]
         embed.description = (
             f"🎴 Nagroda: {self.ilosc}x booster z zestawu `{self.booster_id}`\n"
             f"👑 Zwycięzcy: {self.winners}\n"
-            f"⏳ Zakończenie za: {remaining_seconds // 60}m {remaining_seconds % 60}s\n\n"
+            f"⏳ Zakończenie za: {remaining_str}\n\n"
             f"👥 Uczestnicy ({len(self.entries)}):\n" + (", ".join(names) if names else "Brak")
         )
 


### PR DESCRIPTION
## Summary
- restrict booster summary messages to the shop channel
- show days and hours in giveaway countdown
- ensure booster openings always yield 10 cards

## Testing
- `python -m py_compile bot.py giveaway.py poke_utils.py collect.py`

------
https://chatgpt.com/codex/tasks/task_e_684a8a903398832fb7607b5ceb82baa8