### PR TITLE
Add giveaway title and player profile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
 - `/daily` – codzienna nagroda pieniędzy (24 h cooldown). Co 7 dni serii otrzymasz bonus 200 BC.
 - `/sklep` – otwiera widok sklepu z boosterami i przedmiotami.
 - `/profil` – wyświetla Twój profil z kartami i boosterami.
+- `/profil_gracza` – pokaż uproszczony profil wskazanego gracza.
 - `/osiagniecia` – lista zdobytych osiągnięć.
 - `/ranking` – najlepsze dropy tygodnia.
 - `/help` – lista wszystkich komend bota.


### PR DESCRIPTION
## Summary
- extend giveaway modal with optional title
- restrict `/saldo` and `/ranking` to shop channel
- implement `/profil_gracza` command to view other player's profile
- document new command in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a929f609c832fa940fc59338bc3fe