### PR TITLE
Update event notifications and profile avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
    POKETCG_API_KEY=twoj_klucz_api
    # Opcjonalnie ID emoji bc_coin na Twoim serwerze
    BC_COIN_ID=1381617796282319010
+   # Opcjonalnie ID roli do powiadomień o eventach
+   EVENT_ROLE_ID=123456789012345678
    ```
 3. Uruchom bota:
    ```bash


### PR DESCRIPTION
## Summary
- increase quick bonus event duration to 5 minutes
- notify members with `EVENT_ROLE_ID` on random events
- show player's avatar in `/profil_gracza`
- document `EVENT_ROLE_ID` environment variable

## Testing
- `python -m py_compile bot.py poke_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68512d12c7ec832f9c08f80d49b096e8