### PR TITLE
Fix event loop spam on drop channel

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1197,9 +1197,9 @@ class MyClient(discord.Client):
                         await channel.send(embed=embed, file=file)
                     ev["announced"] = True
                     changed = True
-        if changed:
-            await asyncio.to_thread(save_events, events)
-        await asyncio.sleep(60)
+            if changed:
+                await asyncio.to_thread(save_events, events)
+            await asyncio.sleep(60)
 
     async def booster_queue_worker(self):
         await self.wait_until_ready()


### PR DESCRIPTION
## Summary
- indent the event loop saving/sleeping logic

## Testing
- `python3 -m py_compile bot.py poke_utils.py collect.py giveaway.py`

------
https://chatgpt.com/codex/tasks/task_e_68515ff76fc8832f848af03ed6bcfc11