### PR TITLE
Fix giveaway winners and tidy set view

### DIFF
--- a/giveaway.py
+++ b/giveaway.py
@@ -137,7 +137,8 @@ class GiveawayView(View):
     async def on_timeout(self):
         # Stop any additional timers that might still be running
         self.stop()
-        if not self.entries:
+        entries = list(self.entries)
+        if not entries:
             if self.message:
                 try:
                     await self.message.channel.send("📭 Giveaway zakończył się bez uczestników.")
@@ -145,7 +146,8 @@ class GiveawayView(View):
                     pass
                 await self.finalize_embed()
             return
-        chosen = random.sample(list(self.entries), min(self.winners, len(self.entries)))
+        random.shuffle(entries)
+        chosen = entries[: min(self.winners, len(entries))]
         users = load_users()
         for uid in chosen:
             uid_str = str(uid)


### PR DESCRIPTION
## Summary
- show duplicate count/value when previewing a set
- remove the "sell duplicates" button from set browser
- make set browser public and without the "Twoje sety" header
- ensure giveaway winners are selected only from joined users

## Testing
- `python -m py_compile bot.py giveaway.py poke_utils.py collect.py`

------
https://chatgpt.com/codex/tasks/task_e_685518efd648832f8e9e011454ebd2ce