### PR TITLE
Implement quick booster opening command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
 - `/ranking` – najlepsze dropy tygodnia.
 - `/help` – lista wszystkich komend bota.
 - `/otworz` – otwórz posiadane boostery i odsłaniaj karty jedna po drugiej.
+- `/otworz_szybko` – otwórz booster i pokaż tylko krótkie podsumowanie.
 - `/giveaway` – stwórz losowanie boosterów (administrator).
 - `/nagroda` – przyznaj booster lub monety wybranemu graczowi (administrator).
 


### PR DESCRIPTION
## Summary
- add `/otworz_szybko` command to open booster without reveal animation
- implement `open_booster_quick` helper
- document new command in README

## Testing
- `python -m py_compile bot.py`
- `python -m py_compile poke_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688079004060832f9e5f33e7d5a26dd5