### PR TITLE
Add multi booster quick open

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ wykonywać codzienne zadania oraz handlować przedmiotami w wbudowanym sklepie.
 - `/ranking` – najlepsze dropy tygodnia.
 - `/help` – lista wszystkich komend bota.
 - `/otworz` – otwórz posiadane boostery i odsłaniaj karty jedna po drugiej.
-- `/otworz_szybko` – otwórz booster i pokaż tylko krótkie podsumowanie.
+- `/otworz_szybko` – otwórz jeden lub kilka boosterów i pokaż podsumowanie (parametr `count`).
 - `/giveaway` – stwórz losowanie boosterów (administrator).
 - `/nagroda` – przyznaj booster lub monety wybranemu graczowi (administrator).
 


### PR DESCRIPTION
## Summary
- allow opening multiple boosters at once via `/otworz_szybko`'s new `count` parameter
- aggregate cards in `open_booster_quick` and show top 5 most valuable drops
- update booster removal logic and statistic tracking
- document the new parameter in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68807a9da0f0832fb4885b0ee67b8ef0